### PR TITLE
Fix Undefined variable $image_array in image.php

### DIFF
--- a/image.php
+++ b/image.php
@@ -20,9 +20,9 @@
 															
 						<div class="featured-media">
 						
-							<?php $image_url = wp_get_attachment_image_url( $post->ID, 'full' ); ?>
+							<?php $image_array = wp_get_attachment_image_src( $post->ID, 'full' ); ?>
 						
-							<a href="<?php echo esc_url( $image_url ); ?>" rel="attachment">
+							<a href="<?php echo esc_url( $image_array[0] ); ?>" rel="attachment">
 								<?php echo wp_get_attachment_image( $post->ID, 'post-image' ); ?>
 							</a>
 						


### PR DESCRIPTION
This bug has been introduced in commit 0711af1 and is also referenced here:
https://wordpress.org/support/topic/undefined-variable-image_array/

This PR fixes it and allows the resolution of the attachment to be visible. 
![image](https://github.com/user-attachments/assets/940a06af-e340-4ad8-b91e-1cf601ecc273)
